### PR TITLE
Make the frontend independent from the old API

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -17,18 +17,19 @@
     <link rel="stylesheet" href="vendor/bower_components/leaflet/dist/leaflet.css" type="text/css">
     <link rel="stylesheet" href="vendor/bower_components/leaflet-draw/dist/leaflet.draw.css" type="text/css">
     <link rel="stylesheet" href="vendor/bower_components/leaflet-modal/dist/leaflet.modal.min.css" type="text/css">
-    <link rel="stylesheet" href="vendor/Leaflet.label/dist/leaflet.label.css" type="text/css">
-    <link rel="stylesheet" href="vendor/Skeleton/css/normalize.css" type="text/css">
-    <link rel="stylesheet" href="vendor/Skeleton/css/skeleton.css" type="text/css">
+    <link rel="stylesheet" href="vendor/Leaflet.label/dist/leaflet.label.css" type="text/css"><!-- Deprecated: https://github.com/Leaflet/Leaflet.label -->
+    <link rel="stylesheet" href="vendor/Skeleton/css/normalize.css" type="text/css"><!-- Last commit in 2014: https://github.com/dhg/Skeleton-->
+    <link rel="stylesheet" href="vendor/Skeleton/css/skeleton.css" type="text/css"><!-- Last commit in 2014: https://github.com/dhg/Skeleton-->
     <link rel="stylesheet" href="index.css" type="text/css">
 
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
     <script type="text/javascript" src="vendor/bower_components/leaflet/dist/leaflet.js"></script>
     <script type="text/javascript" src="vendor/bower_components/leaflet-draw/dist/leaflet.draw.js"></script>
     <script type="text/javascript" src="vendor/bower_components/leaflet-polylinedecorator/leaflet.polylineDecorator.js"></script>
     <script type="text/javascript" src="vendor/bower_components/leaflet-modal/dist/Leaflet.Modal.min.js"></script>
     <script type="text/javascript" src="vendor/bower_components/validatinator/js/validatinator.min.js"></script>
-    <script type="text/javascript" src="vendor/Leaflet.TextPath/leaflet.textpath.js"></script>
-    <script type="text/javascript" src="vendor/Leaflet.label/dist/leaflet.label.js"></script>
+    <script type="text/javascript" src="vendor/Leaflet.TextPath/leaflet.textpath.js"></script><!-- Does not seem to be maintained: https://github.com/makinacorpus/Leaflet.TextPath -->
+    <script type="text/javascript" src="vendor/Leaflet.label/dist/leaflet.label.js"></script><!-- Deprecated: https://github.com/Leaflet/Leaflet.label -->
 
 </head>
 

--- a/app/index.html
+++ b/app/index.html
@@ -7,11 +7,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
     <meta name="description" content="Plan and map missions for Il-2: Battle of Stalingrad and Battle of Moscow.">
     <meta name="keywords" content="il2,bos,il2 bos,il-2,battle of stalingrad,il2 bom,bom,battle of moscow,mission planner">
-    <link rel="author" href="https://github.com/gavincabbage">
-    <link rel="canonical" href="il2missionplanner.com">
+    <link rel="author" href="https://github.com/barbinirocco">
+    <link rel="canonical" href="il2missionplanner.link">
     <link rel=icon href=img/favicon.ico type="image/x-icon">
 
-    <title>Il-2 Mission Planner | il2missionplanner.com</title>
+    <title>Il-2 Mission Planner | il2missionplanner.link</title>
 
     <link rel="stylesheet" href="vendor/bower_components/font-awesome/css/font-awesome.min.css" type="text/css">
     <link rel="stylesheet" href="vendor/bower_components/leaflet/dist/leaflet.css" type="text/css">

--- a/app/js/content.js
+++ b/app/js/content.js
@@ -117,8 +117,7 @@ module.exports = (function() {
             defaultZoom: 3,
             minZoom: 2,
             maxZoom: 6,
-            tileUrl: 'https://tiles.il2missionplanner.com/stalingrad/{z}/{x}/{y}.png'
-            //tileUrl: 'file:///Users/fkc930/Development/personal/tiles.il2missionplanner.com/dist/stalingrad/{z}/{x}/{y}.png'
+            tileUrl: 'https://d1w6xpzk1h0aj5.cloudfront.net/stalingrad/{z}/{x}/{y}.png'
         },
         moscow: {
             fullName: 'Moscow',
@@ -136,8 +135,7 @@ module.exports = (function() {
             defaultZoom: 3,
             minZoom: 2,
             maxZoom: 6,
-            tileUrl: 'https://tiles.il2missionplanner.com/moscow/{z}/{x}/{y}.png'
-            //tileUrl: 'file:///Users/fkc930/Development/personal/tiles.il2missionplanner.com/dist/moscow/{z}/{x}/{y}.png'
+            tileUrl: 'https://d1w6xpzk1h0aj5.cloudfront.net/moscow/{z}/{x}/{y}.png'
         },
         luki: {
             fullName: 'Velikie Luki',
@@ -155,8 +153,7 @@ module.exports = (function() {
             defaultZoom: 3,
             minZoom: 2,
             maxZoom: 6,
-            tileUrl: 'https://tiles.il2missionplanner.com/luki/{z}/{x}/{y}.png'
-            //tileUrl: 'file:///Users/fkc930/Development/personal/tiles.il2missionplanner.com/dist/luki/{z}/{x}/{y}.png'
+            tileUrl: 'https://d1w6xpzk1h0aj5.cloudfront.net/luki/{z}/{x}/{y}.png'
         },
         kuban: {
             fullName: 'Kuban',
@@ -174,8 +171,7 @@ module.exports = (function() {
             defaultZoom: 4,
             minZoom: 2,
             maxZoom: 7,
-            tileUrl: 'https://tiles.il2missionplanner.com/kuban/{z}/{x}/{y}.png'
-            //tileUrl: 'http://localhost:5001/kuban/{z}/{x}/{y}.png'
+            tileUrl: 'https://d1w6xpzk1h0aj5.cloudfront.net/kuban/{z}/{x}/{y}.png'
         },
         rheinland: {
             fullName: 'Rheinland',
@@ -193,8 +189,7 @@ module.exports = (function() {
             defaultZoom: 4,
             minZoom: 2,
             maxZoom: 7,
-            tileUrl: 'https://tiles.il2missionplanner.com/rheinland/{z}/{x}/{y}.png'
-            //tileUrl: 'http://localhost:5001/rheinland/{z}/{x}/{y}.png'
+            tileUrl: 'https://d1w6xpzk1h0aj5.cloudfront.net/rheinland/{z}/{x}/{y}.png'
         },
         arras: {
             fullName: 'Arras',
@@ -212,8 +207,7 @@ module.exports = (function() {
             defaultZoom: 3,
             minZoom: 3,
             maxZoom: 5,
-            tileUrl: 'https://tiles.il2missionplanner.com/arras/{z}/{x}/{y}.png'
-            //tileUrl: 'http://localhost:5001/arras/{z}/{x}/{y}.png'
+            tileUrl: 'https://d1w6xpzk1h0aj5.cloudfront.net/arras/{z}/{x}/{y}.png'
         },
         prokhorovka: {
             fullName: 'Prokhorovka',
@@ -231,8 +225,7 @@ module.exports = (function() {
             defaultZoom: 4,
             minZoom: 3,
             maxZoom: 6,
-            tileUrl: 'https://tiles.il2missionplanner.com/prokhorovka/{z}/{x}/{y}.png'
-            //tileUrl: 'http://localhost:5001/prokhorovka/{z}/{x}/{y}.png'
+            tileUrl: 'https://d1w6xpzk1h0aj5.cloudfront.net/prokhorovka/{z}/{x}/{y}.png'
         }
     };
 

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -53,8 +53,7 @@
         streaming: false,
         connected: false,
         changing: false,
-        streamInfo: {},
-        streamingAvailable: webdis.init() // TODO: check if this can be safely removed, this call hangs when the API is down and it should be asyncrhronous
+        streamInfo: {}
     };
 
     // Patch a leaflet bug, see https://github.com/bbecquet/Leaflet.PolylineDecorator/issues/17

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -711,16 +711,26 @@
     * These maps are accessible via a fragment identifier in the url.
     * */
     if (window.location.hash !== '' && !util.isAvailableMapHash(window.location.hash, content.maps)) {
-        var responseBody = null;
-        var url = conf.apiUrl + '/servers/' + window.location.hash.substr(1);
-        var xhr = util.buildGetXhr(url, function() {
-            if (xhr.readyState === 4) {
-                responseBody = JSON.parse(xhr.responseText);
-                importMapState(responseBody.data);
-                fitViewToMission();
-                checkButtonsDisabled();
-            }
-        });
+        let responseBody = null;
+        /*var url = conf.apiUrl + '/servers/' + window.location.hash.substr(1);*/
+        let url = '';
+        switch (window.location.hash) {
+            case '#virtualpilots':
+                url = 'stats.virtualpilots.fi:8000/static/output.json';
+                break;
+            default:
+                url = '';
+        }
+        if (url !== '') {
+            let xhr = util.buildGetXhr(url, function () { // TODO: get the file in a better way
+                if (xhr.readyState === 4) {
+                    responseBody = JSON.parse(xhr.responseText);
+                    importMapState(responseBody.data);
+                    fitViewToMission();
+                    checkButtonsDisabled();
+                }
+            });
+        }
     }
 
     /*

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -716,7 +716,7 @@
         let url = '';
         switch (window.location.hash) {
             case '#virtualpilots':
-                url = 'stats.virtualpilots.fi:8000/static/output.json';
+                url = 'https://hw4bdhqxg9.execute-api.eu-south-1.amazonaws.com/getStoredMap?map=virtualpilots';
                 break;
             default:
                 url = '';
@@ -725,7 +725,7 @@
             let xhr = util.buildGetXhr(url, function () { // TODO: get the file in a better way
                 if (xhr.readyState === 4) {
                     responseBody = JSON.parse(xhr.responseText);
-                    importMapState(responseBody.data);
+                    importMapState(responseBody);
                     fitViewToMission();
                     checkButtonsDisabled();
                 }

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -672,9 +672,44 @@
         });
     }
 
+    /**
+     * Set up the event listeners that manage events relative to map streaming.
+     * If the page is not connected to a streaming server, the callbacks return without doing nothing, so that they
+     * don't break any other functionality.
+     */
+    function setupStreamingEventListeners() {
+        /*
+        * Manage the il2:streamerror DOM event
+        */
+        window.addEventListener('il2:streamerror', function (e) {
+            if (!state.connected) {
+                return;
+            }
+            util.addClass(document.querySelector('a.fa-share-alt'), 'stream-error');
+        });
 
-    // if hash is not in map list, try to get json for that server
-    // TODO: check if this API call is really necessary for a MVP
+        /*
+        * Manage the il2:streamupdate DOM event
+        */
+        window.addEventListener('il2:streamupdate', function (e) {
+            if (!state.connected) {
+                return;
+            }
+            var saveData = e.detail;
+            if (saveData !== 1) {
+                clearMap();
+                importMapState(JSON.parse(saveData));
+            }
+            util.removeClass(document.querySelector('a.fa-share-alt'), 'stream-error');
+            checkButtonsDisabled();
+        });
+    }
+
+
+    /*
+    * This functionality allows external servers to store and embed maps.
+    * These maps are accessible via a fragment identifier in the url.
+    * */
     if (window.location.hash !== '' && !util.isAvailableMapHash(window.location.hash, content.maps)) {
         var responseBody = null;
         var url = conf.apiUrl + '/servers/' + window.location.hash.substr(1);
@@ -1290,38 +1325,10 @@
     });
 
     /*
-    * Manage the il2:streamerror DOM event
-    *
-    * NOTE: this may be responsible for the page not loading.
-    * TODO: check what generates the event.
-    * TODO: refatctor as function, so it can easily be removed and added again later
-    */
-    window.addEventListener('il2:streamerror', function (e) {
-        if (!state.connected) {
-            return;
-        }
-        util.addClass(document.querySelector('a.fa-share-alt'), 'stream-error');
-    });
-
-    /*
-    * Manage the il2:streamupdate DOM event
-    *
-    * NOTE: this may be responsible for the page not loading.
-    * TODO: check what generates the event.
-    * TODO: refatctor as function, so it can easily be removed and added again later
-    */
-    window.addEventListener('il2:streamupdate', function (e) {
-        if (!state.connected) {
-            return;
-        }
-        var saveData = e.detail;
-        if (saveData !== 1) {
-            clearMap();
-            importMapState(JSON.parse(saveData));
-        }
-        util.removeClass(document.querySelector('a.fa-share-alt'), 'stream-error');
-        checkButtonsDisabled();
-    });
+    * This function ensures that the event listeners required to properly manage map streaming are set up correctly.
+    * If the app is not connected to a remote streaming server, the listener callbacks without doing nothing.
+    * */
+    setupStreamingEventListeners();
 
     checkButtonsDisabled();
 

--- a/app/js/webdis.js
+++ b/app/js/webdis.js
@@ -43,8 +43,9 @@ module.exports = (function() {
         },
 
         /**
-         * hmget makes the initial call to the API that checks their status.
-         * TODO: verify where and how this is used, as it appears to be blockign the page when the API is down
+         * hmget made the initial call to the API that checks their status.
+         * The call has been disabled.
+         * I'm keeping the function definition as a placeholder for future functionality.
          *
          * @param key
          * @param fields

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "homepage": "https://github.com/gavincabbage/il2missionplanner.com#readme",
   "devDependencies": {
+    "serve": "^12.0.0",
     "bower": "^1.8.0",
     "brfs": "^1.4.3",
     "browserify": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,11 @@
     "mocha": "^2.4.5",
     "uglify-js": "^2.6.2",
     "watch-run": "^1.2.4",
-    "xhr-mock": "^1.6.0"
+    "xhr-mock": "^1.6.0",
+    "leaflet": "^1.7.1",
+    "js-skeleton": "^3.6.3",
+    "leaflet-draw": "^1.0.4",
+    "leaflet-textpath": "^1.2.3"
   },
   "scripts": {
     "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha app/js/**/*.test.js",


### PR DESCRIPTION
Resolves #2 .

This pull request takes care of the following items:
- making the frontend independent from the previous API/streaming system, so that it can be opened correctly;
- setting up an MVP for embedding maps from game servers' stats websites.

Several elements still need to be taken care of:
- the code needs to be updated to remove deprecated libraries and bring it all up to date;
- the embedding feature needs to be generalized (ideally calling an external API, which MUST be defined precisely by this project so that it can be independently developed/managed);
- the configuration needs to be removed from the version controlled code (it should be compiled into it at a later stage, from local and unversioned configuration files), making the whole project easily deployable by any third party willing to do so.